### PR TITLE
Add node-pre-gyp dependecy

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
+    "@mapbox/node-pre-gyp": "1.x",
     "wrtc": "^0.4.7"
   }
 }


### PR DESCRIPTION
Reference: https://www.npmjs.com/package/node-pre-gyp

Please upgrade to @mapbox/node-pre-gyp: the non-scoped node-pre-gyp package is deprecated and only the @mapbox scoped package will recieve updates in the future